### PR TITLE
Callback on init added

### DIFF
--- a/src/guard.js
+++ b/src/guard.js
@@ -8,11 +8,16 @@ export class _Guard {
     this._swindon = swindon
     this._connection = null
   }
-  init(method_name, positional_args=[], keyword_args={}) {
-    this._backendInit.push({ method_name, positional_args, keyword_args });
+  init(method_name, positional_args=[], keyword_args={}, callback) {
+    this._backendInit.push({ method_name, positional_args, keyword_args, callback });
     if(this._swindon._status == 'active') {
       this._swindon._connection
         .call(method_name, positional_args, keyword_args)
+        .then((data) => {
+          if (callback) {
+            callback(data);
+          }
+        })
     }
     return this;
   }
@@ -55,6 +60,11 @@ export class _Guard {
     const conn = this._connection = this._swindon._connection
     for(let call of this._backendInit) {
       conn.call(call.method_name, call.positional_args, call.keyword_args)
+        .then((data) => {
+          if (call.callback) {
+            call.callback(data);
+          }
+        })
     }
   }
 }

--- a/test/guard.test.js
+++ b/test/guard.test.js
@@ -28,4 +28,22 @@ describe('Basic guard', () => {
     assert(swindon._removeGuard.calledWith(guard))
 
   });
+
+  it('init-callback', (done) => {
+
+    let conn = connection();
+    let swindon = {_connection: conn, _removeGuard: sinon.spy(), _status: 'active'};
+    const initCallback = sinon.spy();
+    let guard = new _Guard(swindon)
+      .init('notifications.subscribe', ['yyy.zzz'], {}, initCallback);
+
+    guard._subscribe();
+    guard._callInits(); //re-init
+
+    setTimeout(() => {  // Let promise resolve
+      assert(initCallback.calledWith('42'));
+      assert(initCallback.callCount === 2);  // on init and on re-init
+      done();
+    }, 0);
+  });
 });

--- a/test/mock-swindon.js
+++ b/test/mock-swindon.js
@@ -2,7 +2,11 @@ import sinon from 'sinon';
 
 class Connection {
   constructor() {
-    this.call = sinon.spy();
+    this.call = sinon.stub().returns(
+        new Promise((accept) => {
+          accept('42');
+        })
+    );
     this.subscribe = sinon.spy(x => this._mock_unsubscribe);
     this._mock_unsubscribe = sinon.spy();
   }


### PR DESCRIPTION
The ability to do anything on successful `init` added by passing callback to `init` method like
```
    guard.init(
        'notifications.subscribe', groups, {}, (data) => {console.log(data)}
    );
```

Callback added as 4-th argument to the `init()` function. Function is called each time websocket is successfully reconnected and processed init message.

Unit tests are included.